### PR TITLE
remove upper php version limit for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "arlo/moodle-enrol_arlo",
     "description": "Arlo integration for Moodle",
     "require": {
-        "php": ">=7.0 <7.3",
+        "php": ">=7.0",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*",
@@ -21,3 +21,4 @@
         }
     ]
 }
+

--- a/composer.lock
+++ b/composer.lock
@@ -287,7 +287,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0 <7.3",
+        "php": ">=7.0",
         "ext-curl": "*",
         "ext-date": "*",
         "ext-dom": "*"


### PR DESCRIPTION
upper php version limit was causing gocd test failure

```
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - This package requires php >=7.0 <7.3 but your PHP version (7.4.26) does not satisfy that requirement.

```